### PR TITLE
[Update] cost is added to all implicit APIs

### DIFF
--- a/ts/src/upbit.ts
+++ b/ts/src/upbit.ts
@@ -23,7 +23,7 @@ export default class upbit extends Exchange {
             'name': 'Upbit',
             'countries': [ 'KR' ],
             'version': 'v1',
-            'rateLimit': 1000,
+            'rateLimit': 50,
             'pro': true,
             // new metainfo interface
             'has': {
@@ -104,68 +104,70 @@ export default class upbit extends Exchange {
                 'fees': 'https://upbit.com/service_center/guide',
             },
             'api': {
+                // 'endpoint','API Cost'
+                // cost = 1000 / (rateLimit * RPS)
                 'public': {
-                    'get': [
-                        'market/all',
-                        'candles/{timeframe}',
-                        'candles/{timeframe}/{unit}',
-                        'candles/seconds',
-                        'candles/minutes/{unit}',
-                        'candles/minutes/1',
-                        'candles/minutes/3',
-                        'candles/minutes/5',
-                        'candles/minutes/10',
-                        'candles/minutes/15',
-                        'candles/minutes/30',
-                        'candles/minutes/60',
-                        'candles/minutes/240',
-                        'candles/days',
-                        'candles/weeks',
-                        'candles/months',
-                        'candles/years',
-                        'trades/ticks',
-                        'ticker',
-                        'ticker/all',
-                        'orderbook',
-                        'orderbook/supported_levels', // Upbit KR only
-                    ],
+                    'get': {
+                        'market/all': 2, // RPS: 10
+                        'candles/{timeframe}': 2,
+                        'candles/{timeframe}/{unit}': 2,
+                        'candles/seconds': 2,
+                        'candles/minutes/{unit}': 2,
+                        'candles/minutes/1': 2,
+                        'candles/minutes/3': 2,
+                        'candles/minutes/5': 2,
+                        'candles/minutes/10': 2,
+                        'candles/minutes/15': 2,
+                        'candles/minutes/30': 2,
+                        'candles/minutes/60': 2,
+                        'candles/minutes/240': 2,
+                        'candles/days': 2,
+                        'candles/weeks': 2,
+                        'candles/months': 2,
+                        'candles/years': 2,
+                        'trades/ticks': 2,
+                        'ticker': 2,
+                        'ticker/all': 2,
+                        'orderbook': 2,
+                        'orderbook/supported_levels': 2, // Upbit KR only
+                    },
                 },
                 'private': {
-                    'get': [
-                        'accounts',
-                        'orders/chance',
-                        'order',
-                        'orders/closed',
-                        'orders/open',
-                        'orders/uuids',
-                        'withdraws',
-                        'withdraw',
-                        'withdraws/chance',
-                        'withdraws/coin_addresses',
-                        'deposits',
-                        'deposits/chance/coin',
-                        'deposit',
-                        'deposits/coin_addresses',
-                        'deposits/coin_address',
-                        'travel_rule/vasps',
-                        'status/wallet', // Upbit KR only
-                        'api_keys', // Upbit KR only
-                    ],
-                    'post': [
-                        'orders',
-                        'orders/cancel_and_new',
-                        'withdraws/coin',
-                        'withdraws/krw', // Upbit KR only
-                        'deposits/krw', // Upbit KR only
-                        'deposits/generate_coin_address',
-                        'travel_rule/deposit/uuid',
-                        'travel_rule/deposit/txid',
-                    ],
-                    'delete': [
-                        'order',
-                        'orders/open',
-                        'orders/uuids',
-                    ],
+                    'get': {
+                        'accounts': 0.67, // RPS: 30
+                        'orders/chance': 0.67,
+                        'order': 0.67,
+                        'orders/closed': 0.67,
+                        'orders/open': 0.67,
+                        'orders/uuids': 0.67,
+                        'withdraws': 0.67,
+                        'withdraw': 0.67,
+                        'withdraws/chance': 0.67,
+                        'withdraws/coin_addresses': 0.67,
+                        'deposits': 0.67,
+                        'deposits/chance/coin': 0.67,
+                        'deposit': 0.67,
+                        'deposits/coin_addresses': 0.67,
+                        'deposits/coin_address': 0.67,
+                        'travel_rule/vasps': 0.67,
+                        'status/wallet': 0.67, // Upbit KR only
+                        'api_keys': 0.67, // Upbit KR only
+                    },
+                    'post': {
+                        'orders': 2.5, // RPS: 8
+                        'orders/cancel_and_new': 2.5, // RPS: 8
+                        'withdraws/coin': 0.67, // RPS: 30
+                        'withdraws/krw': 0.67, // Upbit KR only. RPS: 30
+                        'deposits/krw': 0.67, // Upbit KR only. // RPS: 30
+                        'deposits/generate_coin_address': 0.67, // RPS: 30
+                        'travel_rule/deposit/uuid': 0.67, // RPS: 30, but each deposit can only be queried once every 10 minutes
+                        'travel_rule/deposit/txid': 0.67, // RPS: 30, but each deposit can only be queried once every 10 minutes
+                    },
+                    'delete': {
+                        'order': 0.67, // RPS: 30
+                        'orders/open': 40, // RPS: 0.5
+                        'orders/uuids': 0.67, // RPS: 30
+                    },
                 },
             },
             'fees': {


### PR DESCRIPTION
describe에 작성된 Implicit API 별로 cost를 추가하였습니다. 

cost 계산법은 아래와 같습니다. 

1. https://docs.upbit.com/kr/docs/user-request-guide를 기준으로 API 별 RPS(Request Per Second)을 확인합니다.
2. 예를 들어, 초당 8회 호출 가능한 API는 125ms 입니다. (1000 ms / 8)
3. 이를 기준으로 125ms = 1000 ms / (rateLimit * cost)를 계산해 적절한 cost를 확인합니다. 


