### PR TITLE
Feature/upbit update timeframes

### DIFF
--- a/ts/src/upbit.ts
+++ b/ts/src/upbit.ts
@@ -78,6 +78,7 @@ export default class upbit extends Exchange {
                 'withdraw': true,
             },
             'timeframes': {
+                '1s': 'seconds',
                 '1m': 'minutes',
                 '3m': 'minutes',
                 '5m': 'minutes',
@@ -89,6 +90,7 @@ export default class upbit extends Exchange {
                 '1d': 'days',
                 '1w': 'weeks',
                 '1M': 'months',
+                '1y': 'years',
             },
             'hostname': 'api.upbit.com',
             'urls': {


### PR DESCRIPTION
Upbit API 중 초 캔들, 연 캔들 기능 추가로 인한 기능 추가를 위한 PR 입니다.

현재 describe의 API에 따르면 candles/{timeframe}으로 timeframe에 작성된 값을 불러와 dynamic하게 캔들 범위를 설정해 호출할 수 있습니다. 
```
            'api': {
                'public': {
                    'get': {
                        //  https://docs.upbit.com/kr/docs/user-request-guide
                        'market/all': 3,
                        **'candles/{timeframe}': 3**,
```
 
이를 위해 '1s' : 'seconds', '1y': 'years'를 추가하여 초 캔들, 연 캔들을 지원할 수 있게 수정하였습니다. 

```            
'timeframes': {
                **'1s': 'seconds',**
                '1m': 'minutes',
                '3m': 'minutes',
                '5m': 'minutes',
                '10m': 'minutes',
                '15m': 'minutes',
                '30m': 'minutes',
                '1h': 'minutes',
                '4h': 'minutes',
                '1d': 'days',
                '1w': 'weeks',
                '1M': 'months',
                **'1y': 'years',**
            },
```