### PR TITLE
Feature/upbit add implicit api public get

### DIFF
--- a/ts/src/upbit.ts
+++ b/ts/src/upbit.ts
@@ -109,6 +109,7 @@ export default class upbit extends Exchange {
                         'market/all',
                         'candles/{timeframe}',
                         'candles/{timeframe}/{unit}',
+                        'candles/seconds',
                         'candles/minutes/{unit}',
                         'candles/minutes/1',
                         'candles/minutes/3',
@@ -121,9 +122,12 @@ export default class upbit extends Exchange {
                         'candles/days',
                         'candles/weeks',
                         'candles/months',
+                        'candles/years',
                         'trades/ticks',
                         'ticker',
+                        'ticker/all',
                         'orderbook',
+                        'orderbook/supported_levels', // Upbit KR only
                     ],
                 },
                 'private': {


### PR DESCRIPTION
Add Implicit API definitions to include newly supported Public GET APIs from Upbit.

1. /candles/seconds
  - Upbit KR: https://docs.upbit.com/kr/reference/%EC%B4%88second-%EC%BA%94%EB%93%A4
  - Upbit Global: https://global-docs.upbit.com/reference/seconds-candles
  
2. /candles/years
  - Upbit KR: https://docs.upbit.com/kr/reference/%EB%85%84year-%EC%BA%94%EB%93%A4
  - Upbit Global: https://global-docs.upbit.com/reference/years-candles
  
3. /ticker/all
  - Upbit KR: https://docs.upbit.com/kr/reference/tickers_by_quote
  - Upbit Global: https://global-docs.upbit.com/reference/tickers_by_quote
  
4. /orderbook/supported_levels
  - Upbit KR: https://docs.upbit.com/kr/reference/supported_levels
  - Upbit Global: This API is for KRW so that Upbit Global is not supporting it.
  