### PR TITLE
feat(upbit): define new private POST API methods

### DIFF
--- a/ts/src/upbit.ts
+++ b/ts/src/upbit.ts
@@ -149,9 +149,13 @@ export default class upbit extends Exchange {
                     ],
                     'post': [
                         'orders',
+                        'orders/cancel_and_new',
                         'withdraws/coin',
-                        'withdraws/krw',
+                        'withdraws/krw', // Upbit KR only
+                        'deposits/krw', // Upbit KR only
                         'deposits/generate_coin_address',
+                        'travel_rule/deposit/uuid',
+                        'travel_rule/deposit/txid',
                     ],
                     'delete': [
                         'order',


### PR DESCRIPTION
Hello Teams, I added new private POST API metohds for the updated Upbit exchange support.

Here are the links to the newly supported APIs by Upbit:

1. `privatePostOrdersCancelAndNew`
    - **Upbit KR**: https://docs.upbit.com/kr/reference/%EC%B7%A8%EC%86%8C-%ED%9B%84-%EC%9E%AC%EC%A3%BC%EB%AC%B8
    - **Upbit Global**: https://global-docs.upbit.com/reference/cancel-and-new

2. `privatePostDepositsKrw`
    - **Upbit KR**: https://docs.upbit.com/kr/reference/%EC%9B%90%ED%99%94-%EC%9E%85%EA%B8%88%ED%95%98%EA%B8%B0
    - **Upbit Global**: Upbit KR only
    
3. `privatePostTravelRuleDepositUuid`
    - **Upbit KR**: https://docs.upbit.com/kr/reference/%ED%8A%B8%EB%9E%98%EB%B8%94%EB%A3%B0-uuid
    - **Upbit Global**: https://global-docs.upbit.com/reference/travelrule-uuid
 
4. `privatePostTravelRuleDepositTxid`
    - **Upbit KR**: https://docs.upbit.com/kr/reference/%ED%8A%B8%EB%9E%98%EB%B8%94%EB%A3%B0-txid
    - **Upbit Global**: https://global-docs.upbit.com/reference/travelrule-txid

And also, I added comment on withdraws/krw. ( // Upbit KR only) 
