### PR TITLE
delete(upbit): deprecated privateGetOrders

### DIFF
--- a/ts/src/upbit.ts
+++ b/ts/src/upbit.ts
@@ -135,7 +135,6 @@ export default class upbit extends Exchange {
                         'accounts',
                         'orders/chance',
                         'order',
-                        'orders',
                         'orders/closed',
                         'orders/open',
                         'orders/uuids',


### PR DESCRIPTION
**`privateGetOrders`** is deprecated.
    - **Upbit KR**: https://docs.upbit.com/upbit-lambda/changelog/new_get_orders
    - **Upbit Global**: https://global-docs.upbit.com/changelog/new_get_orders