### PR TITLE
feat(upbit): define new Unified API fetchTradingFees

### DIFF
--- a/ts/src/upbit.ts
+++ b/ts/src/upbit.ts
@@ -8,7 +8,7 @@ import { TICK_SIZE } from './base/functions/number.js';
 import { sha512 } from './static_dependencies/noble-hashes/sha512.js';
 import { sha256 } from './static_dependencies/noble-hashes/sha256.js';
 import { jwt } from './base/functions/rsa.js';
-import type { Balances, Currency, Dict, Dictionary, Int, Market, Num, OHLCV, Order, OrderBook, OrderSide, OrderType, Str, Strings, Ticker, Tickers, Trade, TradingFeeInterface, Transaction, int, DepositAddress, OrderBooks } from './base/types.js';
+import type { Balances, Currency, Dict, Dictionary, Int, Market, Num, OHLCV, Order, OrderBook, OrderSide, OrderType, Str, Strings, Ticker, Tickers, Trade, TradingFeeInterface, Transaction, int, DepositAddress, OrderBooks, TradingFees } from './base/types.js';
 
 //  ---------------------------------------------------------------------------
 
@@ -70,7 +70,7 @@ export default class upbit extends Exchange {
                 'fetchTickers': true,
                 'fetchTrades': true,
                 'fetchTradingFee': true,
-                'fetchTradingFees': false,
+                'fetchTradingFees': 'emulated',
                 'fetchTransactions': false,
                 'fetchWithdrawal': true,
                 'fetchWithdrawals': true,
@@ -1024,6 +1024,30 @@ export default class upbit extends Exchange {
             'percentage': true,
             'tierBased': false,
         };
+    }
+
+    /**
+     * @method
+     * @name upbit#fetchTradingFees
+     * @description fetch the trading fees for markets
+     * @param {object} [params] extra parameters specific to the exchange API endpoint
+     * @returns {object} a [trading fee structure]{@link https://docs.ccxt.com/#/?id=trading-fee-structure}
+     */
+    async fetchTradingFees (params = {}): Promise<TradingFees> {
+        await this.loadMarkets ();
+        const fetchMarketResponse = await this.fetchMarkets ();
+        const response: Dict = {};
+        for (let i = 0; i < fetchMarketResponse.length; i++) {
+            const element: Dict = {};
+            element['maker'] = this.safeString (fetchMarketResponse[i], 'maker');
+            element['taker'] = this.safeString (fetchMarketResponse[i], 'taker');
+            element['symbol'] = this.safeString (fetchMarketResponse[i], 'symbol');
+            element['percentage'] = this.fees.trading.percentage;
+            element['tierBased'] = this.fees.trading.tierBased;
+            element['info'] = fetchMarketResponse[i];
+            response[this.safeString (fetchMarketResponse[i], 'symbol')] = element;
+        }
+        return response;
     }
 
     parseOHLCV (ohlcv, market: Market = undefined): OHLCV {

--- a/ts/src/upbit.ts
+++ b/ts/src/upbit.ts
@@ -70,7 +70,7 @@ export default class upbit extends Exchange {
                 'fetchTickers': true,
                 'fetchTrades': true,
                 'fetchTradingFee': true,
-                'fetchTradingFees': 'emulated',
+                'fetchTradingFees': true,
                 'fetchTransactions': false,
                 'fetchWithdrawal': true,
                 'fetchWithdrawals': true,
@@ -1035,15 +1035,15 @@ export default class upbit extends Exchange {
      */
     async fetchTradingFees (params = {}): Promise<TradingFees> {
         await this.loadMarkets ();
-        const fetchMarketResponse = await this.fetchMarkets ();
+        const fetchMarketResponse = await this.fetchMarkets (params);
         const response: Dict = {};
         for (let i = 0; i < fetchMarketResponse.length; i++) {
             const element: Dict = {};
-            element['maker'] = this.safeString (fetchMarketResponse[i], 'maker');
-            element['taker'] = this.safeString (fetchMarketResponse[i], 'taker');
+            element['maker'] = this.safeNumber (fetchMarketResponse[i], 'maker');
+            element['taker'] = this.safeNumber (fetchMarketResponse[i], 'taker');
             element['symbol'] = this.safeString (fetchMarketResponse[i], 'symbol');
-            element['percentage'] = this.fees.trading.percentage;
-            element['tierBased'] = this.fees.trading.tierBased;
+            element['percentage'] = true;
+            element['tierBased'] = false;
             element['info'] = fetchMarketResponse[i];
             response[this.safeString (fetchMarketResponse[i], 'symbol')] = element;
         }


### PR DESCRIPTION
기존에 받았던 fetchTradingFees 건 입니다. 

1. TradingFee type 추가

2. fetchMarkets를 이용해 필요한 값 추출 후, 응답으로 반환.
```
{
    'ETH/BTC': {
        'maker': 0.001,
        'taker': 0.002,
        'info': { ... },
        'symbol': 'ETH/BTC',
    },
    'LTC/BTC': {
        'maker': 0.001,
        'taker': 0.002,
        'info': { ... },
        'symbol': 'LTC/BTC',
    },
}
```